### PR TITLE
Clarify how to avoid memory-leak warnings with globals.

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ JavaScript `RegExp` objects.
 
 If any instance of a class of this distribution is DESTROY()ed at Perl’s
 global destruction, we assume that this is a memory leak, and a warning is
-thrown. To prevent this, avoid circular references.
+thrown. To prevent this, avoid circular references, and clean up all global
+instances.
 
 Callbacks make that tricky. When you give a JavaScript function to Perl,
 that Perl object holds a reference to the QuickJS context. Only once that

--- a/lib/JavaScript/QuickJS.pm
+++ b/lib/JavaScript/QuickJS.pm
@@ -179,7 +179,8 @@ JavaScript C<RegExp> objects.
 
 If any instance of a class of this distribution is DESTROY()ed at Perl’s
 global destruction, we assume that this is a memory leak, and a warning is
-thrown. To prevent this, avoid circular references.
+thrown. To prevent this, avoid circular references, and clean up all global
+instances.
 
 Callbacks make that tricky. When you give a JavaScript function to Perl,
 that Perl object holds a reference to the QuickJS context. Only once that


### PR DESCRIPTION
Issue #2