### PR TITLE
Add whatis entries to the class manpages.

### DIFF
--- a/lib/JavaScript/QuickJS/Date.pm
+++ b/lib/JavaScript/QuickJS/Date.pm
@@ -7,7 +7,7 @@ use warnings;
 
 =head1 NAME
 
-JavaScript::QuickJS::Date
+JavaScript::QuickJS::Date - Represents a JavaScript Date instance in Perl
 
 =head1 SYNOPSIS
 

--- a/lib/JavaScript/QuickJS/Function.pm
+++ b/lib/JavaScript/QuickJS/Function.pm
@@ -7,7 +7,7 @@ use warnings;
 
 =head1 NAME
 
-JavaScript::QuickJS::Function
+JavaScript::QuickJS::Function - Represents a JavaScript Function instance in Perl
 
 =head1 SYNOPSIS
 

--- a/lib/JavaScript/QuickJS/Promise.pm
+++ b/lib/JavaScript/QuickJS/Promise.pm
@@ -7,7 +7,7 @@ use warnings;
 
 =head1 NAME
 
-JavaScript::QuickJS::Promise
+JavaScript::QuickJS::Promise - Represents a JavaScript Promise instance in Perl
 
 =head1 SYNOPSIS
 

--- a/lib/JavaScript/QuickJS/RegExp.pm
+++ b/lib/JavaScript/QuickJS/RegExp.pm
@@ -7,7 +7,7 @@ use warnings;
 
 =head1 NAME
 
-JavaScript::QuickJS::RegExp
+JavaScript::QuickJS::RegExp - Represents a JavaScript RegExp instance in Perl.
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION
When trying to build a Debian package from your perl package, the Debian checking tool lintian reported, that the man pages of JavaScript::QuickJS::Date. JavaScript::QuickJS::Function, JavaScript::QuickJS::Promise, and JavaScript::QuickJS::RegExp have a bad whatis entry:

N:   A manual page should start with a NAME section, which lists the program
N:   name and a brief description. The NAME section is used to generate a
N:   database that can be queried by commands like apropos and whatis. You are
N:   seeing this tag because lexgrog was unable to parse the NAME section.
N:   
N:   Manual pages for multiple programs, functions, or files should list each
N:   separated by a comma and a space, followed by \- and a common description.
N:   
N:   Listed items may not contain any spaces. A manual page for a two-level
N:   command such as fs listacl must look like fs_listacl so the list is read
N:   correctly.
N: 
N:   Please refer to the lexgrog(1) manual page, the groff_man(7) manual page,
N:   and the groff_mdoc(7) manual page for details.

This pull request tries to fix this warning.
