### PR TITLE
Fix function calls without arguments

### DIFF
--- a/QuickJS.xs
+++ b/QuickJS.xs
@@ -1261,14 +1261,14 @@ call( SV* self_sv, SV* this_sv=&PL_sv_undef, ... )
     CODE:
         perl_qjs_jsobj_s* pqjs = exs_structref_ptr(self_sv);
 
-        U32 params_count = items - FUNC_CALL_INITIAL_ARGS;
+        U32 params_count = items > FUNC_CALL_INITIAL_ARGS ? items - FUNC_CALL_INITIAL_ARGS : 0;
 
         SV* error = NULL;
 
         JSValue thisjs = _sv_to_jsvalue(aTHX_ pqjs->ctx, this_sv, &error);
         if (error) croak_sv(error);
 
-        JSValue jsvars[params_count];
+        JSValue jsvars[params_count + 1];
 
         error = _svs_to_jsvars( aTHX_ pqjs->ctx, params_count, &ST(FUNC_CALL_INITIAL_ARGS), jsvars );
         if (error) {

--- a/t/js_func_to_perl.t
+++ b/t/js_func_to_perl.t
@@ -42,4 +42,12 @@ isa_ok($cb2, 'JavaScript::QuickJS::Function', 'JS callback (declaration)');
 is($cb2->length(), 2, 'length() gives arity');
 is($cb2->name(), q<myFunc>, 'name()');
 
+my $no_args = $js->eval('(function () { return arguments.length; })');
+is($no_args->call(), 0, 'call() accepts an omitted receiver and no arguments');
+is($no_args->call(undef), 0, 'call(undef) passes no arguments');
+is($no_args->(), 0, 'overloaded invocation passes no arguments');
+
+my $receiver = $js->eval('(function () { return this.answer; })');
+is($receiver->call({ answer => 42 }), 42, 'explicit receiver with no arguments');
+
 done_testing();


### PR DESCRIPTION
Calling `$function->call()` without an explicit `this` value makes the unsigned argument count wrap around, which can crash Perl.

Clamp that count to zero and leave one slot in the temporary argument array so zero-argument calls do not create a zero-length C array.

Split out of #14. The bundled QuickJS is unchanged.
