### PR TITLE
Free callback storage when the context is destroyed

### DIFF
--- a/QuickJS.xs
+++ b/QuickJS.xs
@@ -640,6 +640,7 @@ static void _free_jsctx(pTHX_ JSContext* ctx) {
             js_std_free_handlers(rt);
         }
 
+        Safefree(ctxdata->svs);
         Safefree(ctxdata);
 
         JS_FreeContext(ctx);

--- a/t/jsfunc_memory_handling.t
+++ b/t/jsfunc_memory_handling.t
@@ -6,6 +6,7 @@ use warnings;
 use Test::More;
 use Test::Deep;
 use Test::FailWarnings;
+use Scalar::Util qw(weaken);
 
 use JavaScript::QuickJS;
 
@@ -32,6 +33,31 @@ use JavaScript::QuickJS;
 
     undef $return;
 
+}
+
+{
+    my $js = JavaScript::QuickJS->new();
+    my ($weak_state, $weak_callback);
+    {
+        my $state = { increment => 1 };
+        $weak_state = $state;
+        weaken($weak_state);
+
+        my $callback = sub { $_[0] + $state->{increment} };
+        $weak_callback = $callback;
+        weaken($weak_callback);
+        $js->set_globals(add_one => $callback, alias => $callback);
+    }
+    ok(defined $weak_callback, 'context retains registered callbacks');
+
+    my $function = $js->eval('value => add_one(value)');
+    undef $js;
+    is($function->(41), 42, 'exported function retains the callback context');
+    ok(defined $weak_state, 'callback state remains alive with the context');
+
+    undef $function;
+    ok(!defined $weak_callback, 'callbacks are released with the last context owner');
+    ok(!defined $weak_state, 'callback state is released with the last context owner');
 }
 
 done_testing;


### PR DESCRIPTION
`_free_jsctx()` decrements the references held in `ctxdata->svs`, but never frees the array itself. Every context that registers a Perl callback leaks that allocation.

Free the array when the last context owner is released, after decrementing the stored references.

Split out of #14. The bundled QuickJS is unchanged.
